### PR TITLE
Update DB structure

### DIFF
--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -78,10 +78,10 @@ export default {
   },
   methods: {
     insertPlayer: function () {
-      let ref = selectedPoints.child(this.$route.params.session + '_' + localStorage.name).set({
+      selectedPoints.child(this.$route.params.session + '_' + localStorage.name).set({
         session: this.selected.session,
         name: this.selected.name,
-        points: this.selected.points,
+        points: this.selected.points
       })
       this.submit = true
     },
@@ -89,7 +89,7 @@ export default {
       selectedPoints.child(this.index).update({
         session: this.selected.session,
         name: this.selected.name,
-        points: this.selected.points,
+        points: this.selected.points
       })
     }
   },


### PR DESCRIPTION
DB inserts are keyed via `session_player`
Nested within this is the session id, the player name,
 and the points they've selected
Each update by the player overrides their last point-selection
- How do we know if all the players have submitted a response
  and determine when to reveal points?