### PR TITLE
Clear points

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1811,6 +1811,23 @@
         "esutils": "2.0.2"
       }
     },
+    "babel-polyfill": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
@@ -1943,7 +1960,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
@@ -2181,6 +2197,24 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "bootstrap": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
+      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
+    },
+    "bootstrap-vue": {
+      "version": "2.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.11.tgz",
+      "integrity": "sha512-LxR+oL8yKr1DVoWUWTX+XhiT0xaTMH6142u2VSFDm4tewTH8HIrzN2YIl7HLZrw2DIuE9bRMIdWJqqn3aQe7Hw==",
+      "requires": {
+        "bootstrap": "4.1.3",
+        "lodash.get": "4.4.2",
+        "lodash.startcase": "4.4.0",
+        "opencollective": "1.0.3",
+        "popper.js": "1.14.6",
+        "vue-functional-data-merge": "2.0.7"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2562,8 +2596,7 @@
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "check-types": {
       "version": "7.4.0",
@@ -2810,7 +2843,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
       "requires": {
         "restore-cursor": "2.0.0"
       }
@@ -2824,8 +2856,7 @@
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "4.1.0",
@@ -3199,8 +3230,7 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4333,8 +4363,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.11.0",
@@ -4975,7 +5004,6 @@
       "version": "2.2.0",
       "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "dev": true,
       "requires": {
         "chardet": "0.4.2",
         "iconv-lite": "0.4.24",
@@ -5076,7 +5104,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
@@ -6574,7 +6601,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -7290,8 +7316,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "1.0.0",
@@ -7379,8 +7404,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -8488,6 +8512,11 @@
         }
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -8546,6 +8575,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -8817,8 +8851,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -9019,8 +9052,7 @@
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
       "version": "2.11.1",
@@ -9323,8 +9355,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -9447,9 +9478,93 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.2.0"
+      }
+    },
+    "opencollective": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+      "requires": {
+        "babel-polyfill": "6.23.0",
+        "chalk": "1.1.3",
+        "inquirer": "3.0.6",
+        "minimist": "1.2.0",
+        "node-fetch": "1.6.3",
+        "opn": "4.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "chalk": "1.1.3",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.2.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.11",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx": "4.1.0",
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "node-fetch": {
+          "version": "1.6.3",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "opn": {
+          "version": "4.0.2",
+          "resolved": "http://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+          "requires": {
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "opener": {
@@ -9561,8 +9676,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.5",
@@ -9818,14 +9932,12 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -9850,6 +9962,11 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
+    },
+    "popper.js": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
+      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA=="
     },
     "portfinder": {
       "version": "1.0.19",
@@ -12737,8 +12854,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -12980,7 +13096,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
       "requires": {
         "onetime": "2.0.1",
         "signal-exit": "3.0.2"
@@ -13030,7 +13145,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
       "requires": {
         "is-promise": "2.1.0"
       }
@@ -13043,6 +13157,11 @@
       "requires": {
         "aproba": "1.2.0"
       }
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -13606,8 +13725,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slash": {
       "version": "1.0.0",
@@ -14088,7 +14206,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
@@ -14097,14 +14214,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -14295,8 +14410,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
@@ -14339,7 +14453,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -14915,6 +15028,11 @@
           "dev": true
         }
       }
+    },
+    "vue-functional-data-merge": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-2.0.7.tgz",
+      "integrity": "sha512-pvLc+H+x2prwBj/uSEIITyxjz/7ZUVVK8uYbrYMmhDvMXnzh9OvQvVEwcOSBQjsubd4Eq41/CSJaWzy4hemMNQ=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "node build/build.js"
   },
   "dependencies": {
+    "bootstrap-vue": "^2.0.0-rc.11",
     "dotenv-webpack": "^1.5.7",
     "firebase": "^5.5.8",
     "vue": "^2.5.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,8 @@
 </template>
 
 <script>
+import 'bootstrap/dist/css/bootstrap.css'
+import 'bootstrap-vue/dist/bootstrap-vue.css'
 export default {
   name: 'app'
 }

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -3,23 +3,26 @@
     <h1>Pointing Poker</h1>
     <h2>Room: {{ $route.params.session }}</h2>
     <form>
-      <input type="text" name="session" v-model="selected.session">
-      <input type="text" name="name" v-model="selected.name">
+      <input type="hidden" name="session" v-model="selected.session">
+      <input type="hidden" name="name" v-model="selected.name">
       <ul>
         <li v-for="pt in pointsAllowed" :key="pt.id">
           <input :id="pt" type="radio" name="point" v-model="selected.points" :value="pt" @change="updatePoints">
-          <label :for="pt">{{ pt }}</label>
+          <label :for="pt" class="btn btn-secondary">{{ pt }}</label>
         </li>
       </ul>
     </form>
-    <p>Selected Points: {{ selected.point }}</p>
+    <p>Selected Points: {{ selected.points }}</p>
     <div>
       <button @click="clearPoints">Clear Points</button>
     </div>
     <div>
       <h2>Players:</h2>
       <ul>
-        <li v-for="name in uniqPlayers" :key="name.id">{{ name }}</li>
+        <li v-for="player in uniqPlayers" :key="player['.key']">
+          {{ player.name }}
+          <span class="selected-point" v-if="allPointsIn">{{ player.points }}</span>
+        </li>
       </ul>
     </div>
   </div>
@@ -33,7 +36,6 @@
 </template>
 
 <script>
-import uniq from 'lodash/uniq'
 import Firebase from 'firebase'
 let config = {
   apiKey: process.env.VUE_APP_DB_API_KEY,
@@ -105,10 +107,31 @@ export default {
   },
   computed: {
     uniqPlayers () {
-      return uniq(this.poker.map(p => [p.name, p.points]))
+      let players = []
+      let map = new Map()
+      for (let item of this.poker) {
+        if (!map.has(item.name)) {
+          map.set(item.name, true)
+          players.push({
+            name: item.name,
+            points: item.points
+          })
+        }
+      }
+      return players
     },
     name () {
       return this.selected.name
+    },
+    allPointsIn () {
+      let points = []
+      this.uniqPlayers.forEach(function (player) {
+        points.push(player.points)
+      })
+      let filtered = points.filter(function (point) {
+        return point !== ''
+      })
+      return filtered.length === this.uniqPlayers.length
     }
   }
 }
@@ -118,5 +141,8 @@ export default {
 <style scoped>
   li {
     list-style: none;
+  }
+  input[type=radio] {
+    display: none;
   }
 </style>

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -7,8 +7,8 @@
       <input type="hidden" name="name" v-model="selected.name">
       <ul>
         <li v-for="pt in pointsAllowed" :key="pt.id">
-          <input :id="pt" type="radio" name="point" v-model="selected.points" :value="pt" @change="updatePoints">
-          <label :for="pt" class="btn btn-secondary">{{ pt }}</label>
+          <input :id="pt" type="radio" name="point" v-model="selected.points" :value="pt">
+          <label :for="pt" class="btn btn-secondary" @click="updatePoints(pt)">{{ pt }}</label>
         </li>
       </ul>
     </form>
@@ -94,11 +94,11 @@ export default {
       this.submit = true
       localStorage.session = this.$route.params.session
     },
-    updatePoints: function () {
+    updatePoints: function (pt) {
       selectedPoints.child(this.index).update({
         session: this.selected.session,
         name: this.selected.name,
-        points: this.selected.points
+        points: pt
       })
     },
     clearPoints: function () {

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -14,6 +14,9 @@
     </form>
     <p>Selected Points: {{ selected.point }}</p>
     <div>
+      <button @click="clearPoints">Clear Points</button>
+    </div>
+    <div>
       <h2>Players:</h2>
       <ul>
         <li v-for="name in uniqPlayers" :key="name.id">{{ name }}</li>
@@ -90,6 +93,13 @@ export default {
         session: this.selected.session,
         name: this.selected.name,
         points: this.selected.points
+      })
+    },
+    clearPoints: function () {
+      this.poker.forEach(function (player) {
+        selectedPoints.child(player['.key']).update({
+          points: ''
+        })
       })
     }
   },

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="poker" v-if="this.submit && this.name">
+  <div class="poker" v-if="this.$route.params.session === this.session">
     <h1>Pointing Poker</h1>
     <h2>Room: {{ $route.params.session }}</h2>
     <form>
@@ -47,6 +47,7 @@ let config = {
 let app = Firebase.initializeApp(config)
 let db = app.database()
 let selectedPoints = db.ref('poker')
+let players = []
 export default {
   name: 'app',
   firebase: {
@@ -62,6 +63,7 @@ export default {
         16
       ],
       index: this.$route.params.session + '_' + localStorage.name,
+      session: localStorage.session,
       submit: false,
       selected: {
         session: this.$route.params.session,
@@ -79,6 +81,7 @@ export default {
   watch: {
     name (newName) {
       localStorage.name = newName
+      localStorage.session = this.$route.params.session
     }
   },
   methods: {
@@ -89,6 +92,7 @@ export default {
         points: this.selected.points
       })
       this.submit = true
+      localStorage.session = this.$route.params.session
     },
     updatePoints: function () {
       selectedPoints.child(this.index).update({
@@ -98,8 +102,8 @@ export default {
       })
     },
     clearPoints: function () {
-      this.poker.forEach(function (player) {
-        selectedPoints.child(player['.key']).update({
+      players.forEach(function (player) {
+        selectedPoints.child(player.key).update({
           points: ''
         })
       })
@@ -107,12 +111,11 @@ export default {
   },
   computed: {
     uniqPlayers () {
-      let players = []
-      let map = new Map()
+      players = []
       for (let item of this.poker) {
-        if (!map.has(item.name)) {
-          map.set(item.name, true)
+        if (item.session === this.selected.session) {
           players.push({
+            key: item['.key'],
             name: item.name,
             points: item.points
           })

--- a/src/main.js
+++ b/src/main.js
@@ -4,11 +4,13 @@ import Vue from 'vue'
 import App from './App'
 import VueRouter from 'vue-router'
 import VueFire from 'vuefire'
+import BootstrapVue from 'bootstrap-vue'
 
 import Form from './components/Form'
 
 Vue.use(VueRouter)
 Vue.use(VueFire)
+Vue.use(BootstrapVue)
 
 const routes = [
   { path: '/:session', component: Form }


### PR DESCRIPTION
Add method to clear points 

- Method simply updates 'points' node in all data sets to empty string
- - Note that logic doesn't account for multiple sessions

Adjust player list, display points, hide fields

- The player listing has been adjusted to use vanilla JS
- We take this unique array of players, and determine if they've all submitted points
- If all players have submitted points, we will reveal all points
- Correct 'Selected Points:' to actually show radio input val
- Go back to hiding the session and name inputs of the user

Install bootstrap, uninstall uniq 

Import bootstrap for use 

Limit actions to sessions 

- Save session in localStorage to compare to url session
- Limit player list & point updates to those in same session
- - Potential bug: same-name users can't cross-session point

Trigger update method on click of label

- Radio input states remained after points were cleared and the radio inputs are hidden anyway - but the form functionality makes it super easy to display which point values were selected by player
- Labels act as buttons, point values passed directly to the update method