### PR TITLE
Add dotenv for importing Firebase config vals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Vue seems to have changed a lot since 2018, find a rework on branch `main`
 npm install
 ```
 
+Create a personal Firebase project for testing:
+
+1. Run `cp example.env.local .env.local`
+1. Visit https://console.firebase.google.com
+1. Log in with any google account.
+1. Create Project.
+1. Create a Web App.
+1. Create a Realtime Database in whatever region is closest to you.
+1. Copy the values from the JS config block in the browser window into the corresponding env vars in `.env.local`.
+
 ### Compiles and hot-reloads for development
 ```
 npm run serve
@@ -23,4 +33,5 @@ npm run lint
 ```
 
 ### Customize configuration
+
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/example.env.local
+++ b/example.env.local
@@ -1,0 +1,11 @@
+// Populate this file from the Web App & Realtime Database 
+// you create at https://console.firebase.google.com
+// See the README.md for setup details.
+
+VUE_APP_FIREBASE_API_KEY=
+VUE_APP_FIREBASE_AUTH_DOMAIN=
+VUE_APP_FIREBASE_DB_URL=
+VUE_APP_FIREBASE_PROJECT_ID=
+VUE_APP_FIREBASE_STORAGE_BUCKET=
+VUE_APP_FIREBASE_MESSAGING_SENDER_ID=
+VUE_APP_FIREBASE_APP_ID=

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -56,12 +56,8 @@
 </template>
 
 <script>
-import * as Firebase from 'firebase';
-let config = {
-  // @TODO .env
-}
-let app = Firebase.initializeApp(config)
-let db = app.database()
+import FirebaseApp from '../services/Firebase'
+const db = FirebaseApp.database()
 let selectedPoints = db.ref('poker')
 let pokerObservers = []
 let pokerPlayers = []

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 import Vue from 'vue'
 import App from './App.vue'
 import router from './router'

--- a/src/services/Firebase.js
+++ b/src/services/Firebase.js
@@ -1,0 +1,12 @@
+import * as Firebase from 'firebase';
+
+export const Config = {
+  apiKey: process.env.VUE_APP_FIREBASE_API_KEY,
+  authDomain: process.env.VUE_APP_FIREBASE_AUTH_DOMAIN,
+  storageBucket: process.env.VUE_APP_FIREBASE_STORAGE_BUCKET,
+  databaseURL: process.env.VUE_APP_FIREBASE_DB_URL,
+  projectId: process.env.VUE_APP_FIREBASE_PROJECT_ID,
+  messagingSenderId: process.env.VUE_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VUE_APP_FIREBASE_APP_ID,
+}
+export default Firebase.initializeApp(Config)


### PR DESCRIPTION
Also splits the FirebaseApp out into a Service module for consolidated re-use.

And adds README notes for creating your own test Firebase app.